### PR TITLE
Private _logOutput conditional compilation when DISABLE_LOGGING

### DIFF
--- a/ArduinoLog.h
+++ b/ArduinoLog.h
@@ -328,7 +328,9 @@ private:
 
 	void print(const Printable& obj, va_list args)
 	{
+#ifndef DISABLE_LOGGING
 		_logOutput->print(obj);
+#endif
 	}
 
 	void printFormat(const char format, va_list *args);


### PR DESCRIPTION
This avoids  error: '_logOutput' was not declared in this scope when DISABLE_LOGGING is defined.